### PR TITLE
Change distro name retrieval to try to read /etc/os-release first

### DIFF
--- a/tests/__meta__.py
+++ b/tests/__meta__.py
@@ -6,5 +6,6 @@ os.sys.path.insert(0, parentdir)
 import sys
 import platform
 import unittest
+from tracer.resources.system import System
 
-DISTRO = platform.linux_distribution(full_distribution_name=False)[0]
+DISTRO = System.distribution()

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -35,7 +35,18 @@ class System(object):
 
 	@staticmethod
 	def distribution():
-		return platform.linux_distribution(full_distribution_name=False)[0]
+		# Checks if /etc/os-release exists, and if it does,
+		# use it to divine the name of the distribution
+		# Otherwise, revert to using platform.linux_distribution()
+		if os.path.isfile("/etc/os-release"):
+			with open("/etc/os-release") as os_release_file:
+				os_release_data = {}
+				for line in os_release_file:
+					os_release_key, os_release_value = line.rstrip().split("=")
+					os_release_data[os_release_key] = os_release_value.strip('"')
+				return os_release_data["ID"]
+		else:
+			return platform.linux_distribution(full_distribution_name=False)[0]
 
 	@staticmethod
 	def package_manager(**kwargs):


### PR DESCRIPTION
The distribution name check function in Python is somewhat unreliable. For example, in Mageia, it will return `mandrake` instead of `mageia`. Not only that, `platform.linux_distribution()` is deprecated in Python 3.5 in favor of reading `/etc/os-release` anyway.

This pull request alters the distro name retrieval behavior to try to check for `/etc/os-release`, and if it exists, parse the file and return the `ID` value.