### PR TITLE
Add missing BuildRequires for doc generation

### DIFF
--- a/tracer.spec
+++ b/tracer.spec
@@ -16,7 +16,10 @@ Source0:	%{name}-%{version}.tar.gz
 BuildRequires:	python2-devel
 BuildRequires:	asciidoc
 BuildRequires:	python-sphinx
-BuildRequires:	libxslt
+BuildRequires:	python-beautifulsoup4
+BuildRequires:	python-psutil
+BuildRequires:	python-pygments
+BuildRequires:	python-lxml
 BuildRequires:	gettext
 Requires:	rpm-python
 Requires:	python


### PR DESCRIPTION
This adds the missing BuildRequires for documentation generation so that [errors like these don't occur](https://kojipkgs.fedoraproject.org//packages/tracer/0.6.6/1.fc22/data/logs/noarch/build.log):

```
sphinx-build -b man -d build/doctrees   source build/man
Making output directory...
Running Sphinx v1.2.3
loading pickled environment... not yet created
building [man]: all manpages
updating environment: 6 added, 0 changed, 0 removed
reading sources... [ 16%] api
reading sources... [ 33%] developer-guide
reading sources... [ 50%] get-tracer
reading sources... [ 66%] index
reading sources... [ 83%] manpage
reading sources... [100%] user-guide
/builddir/build/BUILD/tracer-0.6.6/doc/source/api.rst:13: WARNING: autodoc: failed to import class u'Query' from module u'tracer.query'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 335, in import_object
    __import__(self.modname)
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/query.py", line 19, in <module>
    from tracer.resources.tracer import Tracer
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/resources/tracer.py", line 21, in <module>
    from psutil import NoSuchProcess
ImportError: No module named psutil
/builddir/build/BUILD/tracer-0.6.6/doc/source/api.rst:24: WARNING: autodoc: failed to import function u'match' from module u'tracer.hooks'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 335, in import_object
    __import__(self.modname)
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/hooks.py", line 21, in <module>
    from tracer.paths import HOOKS_DIRS
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/paths.py", line 22, in <module>
    from tracer.resources.system import System
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/resources/system.py", line 28, in <module>
    import psutil
ImportError: No module named psutil
/builddir/build/BUILD/tracer-0.6.6/doc/source/api.rst:46: WARNING: autodoc: failed to import class u'Application' from module u'tracer.resources.applications'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 335, in import_object
    __import__(self.modname)
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/resources/applications.py", line 21, in <module>
    from bs4 import BeautifulSoup, element
ImportError: No module named bs4
/builddir/build/BUILD/tracer-0.6.6/doc/source/api.rst:50: WARNING: autodoc: failed to import class u'Process' from module u'tracer.resources.processes'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 335, in import_object
    __import__(self.modname)
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/resources/processes.py", line 19, in <module>
    from .collections import ProcessesCollection
  File "/builddir/build/BUILD/tracer-0.6.6/tracer/resources/collections.py", line 22, in <module>
    from psutil import NoSuchProcess
ImportError: No module named psutil
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
writing... tracer.8 { } 
build succeeded, 4 warnings.
Build finished. The manual pages are in build/man.
```