### PR TITLE
Add support for Mageia in packageManagers & tests

### DIFF
--- a/tests/test_dnf.py
+++ b/tests/test_dnf.py
@@ -4,7 +4,7 @@ try:
 	from tracer.packageManagers.dnf import Dnf
 except ImportError: pass
 
-@unittest.skipIf(DISTRO != 'fedora', "Skipping tests because they are distro-specific")
+@unittest.skipIf((DISTRO != 'fedora') and (DISTRO != 'mageia'), "Skipping tests because they are distro-specific")
 class TestDnf(unittest.TestCase):
 	def setUp(self):
 		self.manager = Dnf()

--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() == "fedora":
+if System.distribution() in ["fedora", "mageia"]:
 
 	import subprocess
 	from tracer.packageManagers.rpm import Rpm

--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "centos"]:
+if System.distribution() in ["fedora", "centos", "mageia"]:
 
 	from os import listdir
 	from .ipackageManager import IPackageManager


### PR DESCRIPTION
Mageia support in tracer was incomplete, and bombed out with fun errors like:

```
[root@mgacauldron-dnftst yum.repos.d]# tracer
Traceback (most recent call last):
  File "/usr/bin/tracer", line 34, in <module>
    tracer.main.run()
  File "/usr/lib/python2.7/site-packages/tracer/main.py", line 42, in run
    return router.dispatch()
  File "/usr/lib/python2.7/site-packages/tracer/resources/router.py", line 55, in dispatch
    controller = DefaultController(self.args, self.packages)
  File "/usr/lib/python2.7/site-packages/tracer/controllers/default.py", line 50, in __init__
    System.package_manager(erased=args.erased),
  File "/usr/lib/python2.7/site-packages/tracer/resources/system.py", line 76, in package_manager
    return PackageManager(*map(get_instance, managers[distro]))
  File "/usr/lib/python2.7/site-packages/tracer/resources/system.py", line 59, in get_instance
    return getattr(module, name)(**kwargs)
AttributeError: 'module' object has no attribute 'Dnf'
```

This PR addresses those and also adjusts it so that the tests related to DNF will also run on Mageia.