### PR TITLE
Fix for CentOS 7

### DIFF
--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -45,8 +45,8 @@ class System(object):
                                         try:
 						os_release_key, os_release_value = line.rstrip().split("=")
 						os_release_data[os_release_key] = os_release_value.strip('"')
-                                        except ValueError:
-                                                pass
+					except ValueError:
+						pass
 				return os_release_data["ID"]
 		else:
 			return platform.linux_distribution(full_distribution_name=False)[0]

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -42,7 +42,7 @@ class System(object):
 			with open("/etc/os-release") as os_release_file:
 				os_release_data = {}
 				for line in os_release_file:
-                                        try:
+					try:
 						os_release_key, os_release_value = line.rstrip().split("=")
 						os_release_data[os_release_key] = os_release_value.strip('"')
 					except ValueError:

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -42,8 +42,11 @@ class System(object):
 			with open("/etc/os-release") as os_release_file:
 				os_release_data = {}
 				for line in os_release_file:
-					os_release_key, os_release_value = line.rstrip().split("=")
-					os_release_data[os_release_key] = os_release_value.strip('"')
+                                        try:
+						os_release_key, os_release_value = line.rstrip().split("=")
+						os_release_data[os_release_key] = os_release_value.strip('"')
+                                        except ValueError:
+                                                pass
 				return os_release_data["ID"]
 		else:
 			return platform.linux_distribution(full_distribution_name=False)[0]


### PR DESCRIPTION
On CentOS 7, the file `/etc/os-release` is:
```
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

```

It contains empty lines. That triggers an exception with tracer-0.6.7:
```
Traceback (most recent call last):
  File "/bin/tracer", line 34, in <module>
    tracer.main.run()
  File "/usr/lib/python2.7/site-packages/tracer/main.py", line 42, in run
    return router.dispatch()
  File "/usr/lib/python2.7/site-packages/tracer/resources/router.py", line 52, in dispatch
    controller = DefaultController(self.args, self.packages)
  File "/usr/lib/python2.7/site-packages/tracer/controllers/default.py", line 50, in __init__
    System.package_manager(erased=args.erased),
  File "/usr/lib/python2.7/site-packages/tracer/resources/system.py", line 72, in package_manager
    distro = System.distribution()
  File "/usr/lib/python2.7/site-packages/tracer/resources/system.py", line 45, in distribution
    os_release_key, os_release_value = line.rstrip().split("=")
ValueError: need more than 1 value to unpack
```

This commit fixes the issue by ignoring lines that does not have a `=`.