### PR TITLE
Add RHEL support

### DIFF
--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "centos", "mageia"]:
+if System.distribution() in ["fedora", "rhel", "centos", "mageia"]:
 
 	from os import listdir
 	from .ipackageManager import IPackageManager

--- a/tracer/packageManagers/yum.py
+++ b/tracer/packageManagers/yum.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "centos"]:
+if System.distribution() in ["fedora", "rhel", "centos"]:
 
 	from tracer.packageManagers.rpm import Rpm
 

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -64,6 +64,7 @@ class System(object):
 		managers = {
 			"gentoo": [("tracer.packageManagers.portage", "Portage")],
 			"debian": [("tracer.packageManagers.dpkg", "Dpkg")],
+			"rhel":   [("tracer.packageManagers.yum", "Yum")],
 			"centos": [("tracer.packageManagers.yum", "Yum")],
 			"mageia": [("tracer.packageManagers.dnf", "Dnf")],
 			"arch":   [("tracer.packageManagers.alpm", "Alpm")],


### PR DESCRIPTION
We can add RHEL support by simply replicating everything that says "centos" using "rhel".

Fixes issue #57