### PR TITLE
Refactor spec file to support Py2 + Py3 coinstallable and add note of Mageia being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Tracer determines which applications use outdated files and prints them. For spe
 Please see [User Guide](http://docs.tracer-package.com/en/latest/user-guide/)
 
 ## Requirements
-- Supported linux distribution - There are currently supported [Fedora](http://fedoraproject.org/), [Gentoo](http://www.gentoo.org/), [Debian](https://www.debian.org/), and [Arch](https://archlinux.org)
+- Supported linux distribution - There are currently supported [Fedora](http://fedoraproject.org/), [Mageia](https://www.mageia.org/), [Gentoo](http://www.gentoo.org/), [Debian](https://www.debian.org/), and [Arch](https://archlinux.org)
 - Python interpreter (tracer is compatible with both 2.7 and 3.x)
 - Python [psutil](https://code.google.com/p/psutil/) module. Available [here](https://admin.fedoraproject.org/pkgdb/acls/name/python-psutil) and [here](https://packages.gentoo.org/package/dev-python/psutil).
 - Python [beautifulsoup](http://www.crummy.com/software/BeautifulSoup/bs4/doc/) module. Available [here](https://admin.fedoraproject.org/pkgdb/acls/name/python-beautifulsoup4) and [here](https://packages.gentoo.org/package/dev-python/beautifulsoup)

--- a/tracer.spec
+++ b/tracer.spec
@@ -105,15 +105,14 @@ This is the Python 3 version.
 make %{?_smp_mflags} man
 
 %py2_build
-sed "s/\/usr\/bin\/python/\/usr\/bin\/python2/" bin/tracer.py > bin/tracer-2
-chmod +x bin/tracer-2
+sed "s/\/usr\/bin\/python/\/usr\/bin\/python2/" bin/tracer.py > bin/tracer
 
 %if %{with python3}
 %py3_build
-sed "s/\/usr\/bin\/python/\/usr\/bin\/python3/" bin/tracer.py > bin/tracer-3
-chmod +x bin/tracer-3
+sed "s/\/usr\/bin\/python/\/usr\/bin\/python3/" bin/tracer.py > bin/tracer
 %endif
 
+chmod +x bin/tracer
 
 %install
 # @TODO use following macros
@@ -124,17 +123,12 @@ mkdir -p %{buildroot}/%{_datadir}/tracer
 mkdir -p %{buildroot}/%{_mandir}/man8
 
 mkdir -p %{buildroot}/%{python2_sitelib}/tracer
-cp -a bin/tracer-2 %{buildroot}/%{_bindir}/
+cp -a bin/tracer %{buildroot}/%{_bindir}/
 cp -ar tracer/* tests %{buildroot}/%{python2_sitelib}/tracer/
 
 %if %{with python3}
 mkdir -p %{buildroot}/%{python3_sitelib}/tracer
-cp -a bin/tracer-3 %{buildroot}/%{_bindir}/
 cp -ar tracer/* tests %{buildroot}/%{python3_sitelib}/tracer/
-ln -s %{_bindir}/tracer-3 %{buildroot}/%{_bindir}/tracer
-%else
-ln -s %{_bindir}/tracer-2 %{buildroot}/%{_bindir}/tracer
-%endif
 
 cp -a data/* %{buildroot}/%{_datadir}/tracer/
 install -m644 doc/build/man/tracer.8 %{buildroot}/%{_mandir}/man8/
@@ -154,13 +148,11 @@ make DESTDIR=%{buildroot}/usr/share/ mo
 %files -n python2-%{name}
 %license LICENSE
 %{python2_sitelib}/tracer
-%{_bindir}/tracer-2
 
 %if %{with python3}
 %files -n python3-%{name}
 %license LICENSE
 %{python3_sitelib}/tracer
-%{_bindir}/tracer-3
 %endif
 
 


### PR DESCRIPTION
This pull request contains two specific changes: a refactor the spec file and an addition to README.md that Mageia is supported with `tracer`.

The refactored spec file is derived from [my packaging of tracer in Mageia](http://svnweb.mageia.org/packages/cauldron/tracer/current/SPECS/tracer.spec?view=markup&pathrev=1055956), which enables `python2-tracer` and `python3-tracer` to be co-installable. Once again, there's a `tracer` package that merely selects the correct version and uses that.

The `tracer-common` subpackage includes the files common to both, which enables the Python 2 and Python 3 versions to be co-installable.

It also properly disables the Python 3 build for RHEL 7 and older and pulls in the Python 2 macros as a build requirement for it to build properly there.