### PR TITLE
dhclient can be restarted via NetworkManager

### DIFF
--- a/data/applications.xml
+++ b/data/applications.xml
@@ -107,6 +107,7 @@
 		<app name="wicd" />
 		<app name="firewalld" />
 		<app name="accounts-daemon" />
+               <app name="dhclient" rename="NetworkManager" />
 	</group>
 
 	<group type="static">


### PR DESCRIPTION
```
[root@centos7-katello-client tracer]# tracer -e
You should restart:
  * Some applications using:
      sudo systemctl restart sshd
      sudo systemctl restart tuned

  * These applications manually:
      dhclient
      master
      pickup
      python
      qmgr
[root@centos7-katello-client tracer]# systemctl restart NetworkManager
[root@centos7-katello-client tracer]# tracer -e
You should restart:
  * Some applications using:
      sudo systemctl restart sshd
      sudo systemctl restart tuned

  * These applications manually:
      master
      pickup
      python
      qmgr
[root@centos7-katello-client tracer]#
```