### PR TITLE
Fixes #68 - recognised SSH sessions correctly

### DIFF
--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -49,6 +49,10 @@ class ProcessMock(object):
 	def is_interpreted(self):
 		return False
 
+	@property
+	def is_session(self):
+                return False
+
 	def create_time(self):
 		return self._create_time
 

--- a/tracer/resources/applications.py
+++ b/tracer/resources/applications.py
@@ -188,8 +188,17 @@ class Application:
 		return self.instances and self.instances[0].is_interpreted
 
 	@property
+	def is_session(self):
+                return self.instances and self.instances[0].is_session
+
+	@property
 	def type(self):
-		return Applications.TYPES["DAEMON"] if self.has_service_file else self._attributes["type"]
+                if self.is_session:
+                        return Applications.TYPES["SESSION"]
+                elif self.has_service_file:
+                        return Applications.TYPES["DAEMON"]
+                else:
+                        return self._attributes["type"]
 
 	@property
 	def has_service_file(self):

--- a/tracer/resources/processes.py
+++ b/tracer/resources/processes.py
@@ -22,6 +22,7 @@ import psutil
 import datetime
 import time
 import os
+import re
 
 
 class Processes(object):
@@ -180,6 +181,13 @@ class Process(ProcessWrapper):
 	def is_interpreted(self):
 		# @TODO implement better detection of interpreted processes
 		return self.name() in ["python"]
+
+	@property
+	def is_session(self):
+                if self.terminal() is not None:
+                        return True
+                if re.search("sshd\:\ .*\ \[priv\]", str(self.cmdline())):
+                        return True
 
 	@property
 	def real_name(self):


### PR DESCRIPTION
This ensure all processes with a TTY are 'SESSION' type. We also match ssh sessions against a regex as they don't have a TTY but should be 'SESSION' type.