### PR TITLE
Fix daemon configuration for udisksd and upowerd

### DIFF
--- a/data/applications.xml
+++ b/data/applications.xml
@@ -125,15 +125,15 @@
 		<app name="tlsmgr" rename="postfix" />
 		<app name="lvmetad" rename="lvm2-lvmetad" />
 		<app name="polkitd" rename="polkit"/>
+		<app name="udisksd" rename="udisks2"/>
+		<app name="upowerd" rename="upower"/>
 	</group>
 
 	<group type="static">
 		<app name="dbus-daemon" />
-		<app name="udisksd" />
 		<app name="gvfsd-metadata" />
 		<app name="at-spi-bus-launcher" />
 		<app name="gconfd-2" />
-		<app name="upowerd" />
 		<app name="systemd" />
 	</group>
 


### PR DESCRIPTION
This issue is similar to #76.

Tested the restarting of the udisksd and upowerd daemon on CentOS 7:

    # tracer -e -a    # -> lists udiskd + upowerd
    # systemctl restart udisks2.service
    # systemctl restart upower.service
    # tracer -e -a    # -> doesn't list udiskd + upowerd anymore