### PR TITLE
Eliminate psutil/beautifulsoup4 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from distutils.core import setup
-from tracer.version import __version__
 
 
 if not os.path.exists('build/pip'):
@@ -12,13 +11,17 @@ shutil.copyfile('bin/tracer.py', 'build/tracer')
 with open("requirements.txt") as f:
 	install_requires = f.read().splitlines()
 
+with open("tracer.spec") as f:
+    version = next(iter(filter(lambda l:l.startswith('Version:'),
+        f.read().splitlines()))).split()[1]
+
 data_files = []
 if hasattr(os, 'geteuid') and os.geteuid() == 0:
     data_files = [('/etc/bash_completion.d', ['scripts/tracer.bash_completion']),]
 
 setup(
 	name='tracer',
-	version=__version__,
+	version=version,
 	author='FrostyX',
 	author_email='frostyx@email.cz',
 	url='http://tracer-package.com/',


### PR DESCRIPTION
Importing `tracer.version` in the setup.py file yields the
evaluation of `tracer/__init__.py` - which ultimately leads to
the importing of psutil/beautifulsoup4.

Thus, a `pip install .` fails on a minimal system (that doesn't
already have those packages installed). For example when you are
in a Python virtual environment.

Note: if you want to test tracer in a virtual env you also have
to make the system's rpm package available (e.g. via linking
/usr/lib64/python2.7/site-packages/rpm to the virtual
site-packages directory).