### PR TITLE
Fix argparse logic in spec

### DIFF
--- a/tracer.spec
+++ b/tracer.spec
@@ -88,7 +88,7 @@ Requires:       python3-lxml
 Requires:       python3-setuptools
 Requires:       python3-dbus
 Requires:       %{name}-common = %{version}-%{release}
-%if %{with suggest}
+%if ! %{with suggest}
 Suggests:       python3-argcomplete
 %else
 Requires:       python-argcomplete


### PR DESCRIPTION
There seems to be a problem that on F27 (maybe also others) python3-tracer transitively depends on python2-argparse.

See the issue description on [RhBug: 1492078](https://bugzilla.redhat.com/show_bug.cgi?id=1492078)

I think, that this is a solution for it.
@sean797, you wrote the particular condition in spec, do you agree with this PR, or am I missing something?