### PR TITLE
Support current versions of DNF

### DIFF
--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import
 
+import os.path
 
 from tracer.resources.system import System
 if System.distribution() in ["fedora", "mageia"]:
@@ -27,8 +28,16 @@ if System.distribution() in ["fedora", "mageia"]:
 
 	class Dnf(Rpm):
 
+		def __init__(self, **kwargs):
+			super(Dnf, self).__init__(**kwargs)
+			if os.path.exists('/var/lib/dnf/history.sqlite'):
+				self.opts['modern_swdb'] = True
+
 		@property
-		def history_path(self): return '/var/lib/dnf/history/'
+		def history_path(self):
+			if self.opts.get('modern_swdb'):
+				return '/var/lib/dnf/history.sqlite'
+			return '/var/lib/dnf/history/'
 
 		def package_files(self, pkg_name):
 			if self._is_installed(pkg_name):


### PR DESCRIPTION
This will fail again if the schema changes substantially again.

It might be a good idea to investigate using the Python YUM/DNF libraries to get this information. Additionally, if a new version of DNF is or was at one point installed, but either YUM or an old version of DNF has since been used, transactions made by YUM or old DNF will not be captured. This shouldn't affect most systems, but could affect CentOS 7 systems on which [YUM 4] has been installed and then either removed or ignored in favor of the system YUM.

Fixes #116.

[YUM 4]: https://blog.centos.org/2017/10/yum-4-is-available-for-testing/