### PR TITLE
Test in Ubuntu Xenial images with current Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-dist: trusty
+dist: xenial
 sudo: false
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "nightly"
 
 addons:
@@ -17,16 +17,11 @@ addons:
       - libdbus-glib-1-dev
 
 install:
-  # These first 2 lines are a nasty Travis hack, see https://github.com/travis-ci/travis-ci/issues/653
-  - sed -i "s|not getvar('Py_ENABLE_SHARED')|True|" /opt/python/3.3.6/bin/python3.3-config || true
-  - sed -i "s|not getvar('Py_ENABLE_SHARED')|True|" $(which python)-config || true
-
-  - PATH=/opt/python/3.3.6/bin/:$PATH pip install -r requirements.txt
-  - PATH=/opt/python/3.3.6/bin/:$PATH pip install .  # See setup.py
-  - PATH=/opt/python/3.3.6/bin/:$PATH pip install coveralls
+  - pip install -r requirements.txt
+  - pip install .  # See setup.py
+  - pip install coveralls
 
 script:
-  - export PYTHONPATH=/opt/python/3.3.6/lib/python3.3/site-packages/
   - dbus-launch --exit-with-session nosetests -v -d --with-coverage --cover-package=tracer --cover-inclusive
 
 notifications:


### PR DESCRIPTION
Current versions of dbus-python [have a requirement on dbus >= 1.8][dbus], which isn't met on Ubuntu Trusty. This shouldn't be an issue when deployed, as the version of dbus-python in use will be whatever is provided by the distro.

Additionally, this removes testing on Python 3.3, which has been end-of-lifed, and adds testing on Python 3.7.

[dbus]: https://cgit.freedesktop.org/dbus/dbus-python/commit/?id=05ef07b9b5a6ae4b53dc80728563d2455fe7e24f