### PR TITLE
Improve session detection logic

### DIFF
--- a/tracer/resources/processes.py
+++ b/tracer/resources/processes.py
@@ -245,8 +245,12 @@ class Process(with_metaclass(ProcessMeta, ProcessWrapper)):
 
 	@property
 	def is_session(self):
-                if self.terminal() is not None:
-                        return True
+		terminal = self.terminal()
+		if terminal is None:
+			return None
+		parent = self.parent()
+		if parent is None or terminal != parent.terminal():
+			return True
 
 	@property
 	def real_name(self):


### PR DESCRIPTION
`Process.terminal()` returns the path to the terminal attached to the process, if one exists. This will include most processes launched interactively, not just processes that represent sessions. This implements a new heuristic, in which a process is a session if it has a terminal attached and either somehow has no parent or its parent has a different terminal attached. This heuristic is probably not foolproof, but should be sufficient for the majority of cases.

Fixes #119.