### PR TITLE
Ignore debug kernels when checking if kernel has been updated

### DIFF
--- a/tracer/resources/tracer.py
+++ b/tracer/resources/tracer.py
@@ -132,9 +132,11 @@ class Tracer(object):
 	def _has_updated_kernel(self):
 		if os.path.isdir('/lib/modules/'):
 			for k_version in next(os.walk('/lib/modules/'))[1]:
+				if 'debug' in k_version:
+					continue
+
 				if parse_version(os.uname()[2]) < parse_version(k_version):
 					return True
-			return False
 		return False
 
 	def _apply_rules(self, process):


### PR DESCRIPTION
This prevents a false positive in `_has_updated_kernel` when a newer kernel-debug package is installed compared to the running kernel. Now it will return False

```
[root@rhel7 tracer]# rpm -q kernel
kernel-3.10.0-1062.el7.x86_64
[root@rhel7 tracer]# ll /lib/modules/
total 8
drwxr-xr-x. 7 root root 4096 Mar 26 16:45 3.10.0-1062.18.1.el7.x86_64.debug
drwxr-xr-x. 7 root root 4096 Aug  8  2019 3.10.0-1062.el7.x86_64
[root@rhel7 tracer]# tracer -a
# no restart needed
```

Bugzilla report: https://bugzilla.redhat.com/show_bug.cgi?id=1709842
