### PR TITLE
Use package manager to determine latest kernel

### DIFF
--- a/tracer/packageManagers/ipackageManager.py
+++ b/tracer/packageManagers/ipackageManager.py
@@ -42,6 +42,20 @@ class IPackageManager(object):
 		"""Returns name of package which provides given application"""
 		raise NotImplementedError
 
+	def find_package(self, pkg_name, search):
+		"""Find a package by name and some other input criteria"""
+		raise NotImplementedError
+
+	def compare_packages(self, package1, package2):
+		"""
+		Compares two packages by their version information
+		Returns:
+		0 if they are equal
+		1 if package1 > package2
+		-1 if package2 > package1
+		"""
+		raise NotImplementedError
+
 	@staticmethod
 	def _pkg_name_without_version(pkg_name):
 		try:

--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -27,7 +27,6 @@ if System.distribution() in ["fedora", "rhel", "centos", "mageia", "ol"]:
 	from tracer.resources.package import Package
 	from tracer.resources.collections import PackagesCollection
 	from tracer.resources.exceptions import LockedDatabase, DatabasePermissions
-	from tracer.resources.applications import Applications
 	import sqlite3
 	import rpm
 	import os
@@ -109,18 +108,53 @@ if System.distribution() in ["fedora", "rhel", "centos", "mageia", "ol"]:
 			# Tracer will not find uninstalled applications
 			return []
 
+		def find_package(self, name, evra):
+			evra = self._splitEvra(evra)
+			ts = rpm.TransactionSet()
+			mi = ts.dbMatch("name", name)
+
+			for hdr in mi:
+				if hdr[rpm.RPMTAG_EPOCH] == evra[0] and hdr[rpm.RPMTAG_VERSION] == evra[1] and hdr[rpm.RPMTAG_RELEASE] == evra[2] and hdr[rpm.RPMTAG_ARCH] == evra[3]:
+					package = Package(name)
+					self._load_package_info_from_hdr(package, hdr)
+
+					return package
+
+			return None
+
 		def load_package_info(self, package):
 			"""From database load informations about given package and set them to it"""
-			description = None
-			category = None
 			if not package:
 				return None
 
 			ts = rpm.TransactionSet()
 			mi = ts.dbMatch("name", package.name)
-			package_hdr = next(mi)
-			package.description = package_hdr[rpm.RPMTAG_SUMMARY].decode()
-			package.category = package_hdr[rpm.RPMTAG_GROUP].decode()
+
+			""" Find the latest one if there are multiple versions"""
+			latest = None
+			for hdr in mi:
+				if latest is None:
+					latest = hdr
+				else:
+					compare = rpm.labelCompare((str(latest[rpm.RPMTAG_EPOCH]), str(latest[rpm.RPMTAG_VERSION]), str(latest[rpm.RPMTAG_RELEASE])),
+						(str(hdr[rpm.RPMTAG_EPOCH]), str(hdr[rpm.RPMTAG_VERSION]), str(hdr[rpm.RPMTAG_RELEASE])))
+
+					if compare == -1:
+						latest = hdr
+
+			if latest is None:
+				return
+
+			self._load_package_info_from_hdr(package, latest)
+
+		def compare_packages(self, p1, p2):
+			"""
+			labelCompare returns:
+			0 if the EVR matches
+			1 if EVR(1) > EVR(2)
+			-1 if EVR(2) > EVR(1)
+			"""
+			return rpm.labelCompare((str(p1.epoch), str(p1.version), str(p1.release)), (str(p2.epoch), str(p2.version), str(p2.release)))
 
 		def provided_by(self, app):
 			"""Returns name of package which provides given application"""
@@ -136,6 +170,43 @@ if System.distribution() in ["fedora", "rhel", "centos", "mageia", "ol"]:
 							return package if package else None
 				return package
 			return None
+
+		def _splitEvra(self, evra):
+			"""
+			Derived from rpmUtils.miscutils.splitFilename
+			https://github.com/rpm-software-management/yum/blob/master/rpmUtils/miscutils.py
+
+			Given: 9-123a.ia64
+			Return: (9, 123a, 1, ia64)
+			"""
+
+			archIndex = evra.rfind('.')
+			arch = evra[archIndex + 1:]
+
+			relIndex = evra[:archIndex].rfind('-')
+			rel = evra[relIndex + 1:archIndex]
+
+			verIndex = evra[:relIndex].rfind('-')
+			ver = evra[verIndex + 1:relIndex]
+
+			epochIndex = evra.find(':')
+			if epochIndex == -1:
+				epoch = None
+			else:
+				epoch = evra[:epochIndex]
+
+			return epoch, ver, rel, arch
+
+		def _load_package_info_from_hdr(self, package, hdr):
+			package.description = hdr[rpm.RPMTAG_SUMMARY].decode()
+			package.category = hdr[rpm.RPMTAG_GROUP].decode()
+
+			epoch = hdr[rpm.RPMTAG_EPOCH]
+			if epoch:
+				package.epoch = epoch.decode()
+
+			package.version = hdr[rpm.RPMTAG_VERSION].decode()
+			package.release = hdr[rpm.RPMTAG_RELEASE].decode()
 
 		def _file_provided_by(self, file):
 			"""Returns name of package which provides given file"""

--- a/tracer/resources/PackageManager.py
+++ b/tracer/resources/PackageManager.py
@@ -61,3 +61,17 @@ class PackageManager:
 	def provided_by(self, app):
 		"""Returns name of package which provides given application"""
 		return self.package_managers[0].provided_by(app)
+
+	def find_package(self, pkg_name, search):
+		"""Find a package by name and some other input criteria"""
+		return self.package_managers[0].find_package(pkg_name, search)
+
+	def compare_packages(self, package1, package2):
+		"""
+		Compares two packages by their version information
+		Returns:
+		0 if they are equal
+		1 if package1 > package2
+		-1 if package2 > package1
+		"""
+		return self.package_managers[0].compare_packages(package1, package2)

--- a/tracer/resources/package.py
+++ b/tracer/resources/package.py
@@ -26,6 +26,9 @@ class Package:
 	modified = None  #: UNIX timestamp of the modification
 	description = None
 	category = None
+	epoch = None
+	version = None
+	release = None
 
 	def __init__(self, name, modified=None):
 		self.name = name

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -30,7 +30,6 @@ from sys import version_info
 from tracer.resources.PackageManager import PackageManager
 from tracer.resources.processes import Process
 
-
 class System(object):
 
 	@staticmethod
@@ -111,6 +110,15 @@ class System(object):
 	@staticmethod
 	def python_version():
 		return "{}.{}.{}".format(version_info.major, version_info.minor, version_info.micro)
+
+	@staticmethod
+	def running_kernel_package():
+		return System.package_manager().find_package(System.kernel_package_name(), os.uname()[2])
+
+	@staticmethod
+	def kernel_package_name():
+		""" TODO: infer kernel package from current distribution """
+		return 'kernel'
 
 	@staticmethod
 	def user():


### PR DESCRIPTION
There are cases when uninstalling a kernel will leave files behind in /lib/modules resulting in a false positive for `_has_updated_kernel`. This PR changes that method to rely on the system's package data to determine the latest installed version and compare the running kernel to it.

Turns out this is actually quite complex. To truly make a comparison on an RPM system we need to look at the package EVR closely. I don't have the capacity to update the other package managers - and I'd say they weren't truly working anyway with the old approach - so no difference there. I've attempted to organize the code in a way that makes it easy to extend functionality to the other distros.