### PR TITLE
Use DNF on RHEL

### DIFF
--- a/tracer/controllers/default.py
+++ b/tracer/controllers/default.py
@@ -143,7 +143,7 @@ class DefaultController(object):
 		]) if not args.all else applications
 
 	def _user(self, user):
-		if   user == '*':    return None
+		if   user == ['*'] or '*':    return None
 		elif user == 'root': return user
 		elif not user:       return System.user()
 		else: return user[0]

--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 import os.path
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "mageia"]:
+if System.distribution() in ["rhel", "fedora", "mageia"]:
 
 	import subprocess
 	from tracer.packageManagers.rpm import Rpm

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -72,7 +72,10 @@ class System(object):
 		managers = {
 			"gentoo":  [("tracer.packageManagers.portage", "Portage")],
 			"debian":  [("tracer.packageManagers.dpkg", "Dpkg")],
-			"rhel":    [("tracer.packageManagers.yum", "Yum")],
+			"rhel":  [
+				("tracer.packageManagers.dnf", "Dnf"),
+				("tracer.packageManagers.yum", "Yum"),
+			],
 			"centos":  [("tracer.packageManagers.yum", "Yum")],
 			"ol":      [("tracer.packageManagers.yum", "Yum")],
 			"mageia":  [("tracer.packageManagers.dnf", "Dnf")],


### PR DESCRIPTION
Traces were not being reported accurately because the transaction DB wasn't getting found due to using the Yum package manager.

This also fixes an issue with the --user flag so it can take both `*` and `"*"` to avoid confusion