### PR TITLE
Drop beautifulsoup4 in favor of built-in xml.dom

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,8 +1,25 @@
 from .__meta__ import *
+from tracer.paths import DATA_DIR
 from tracer.resources.rules import Rules, Rule
+
+try:
+	from unittest.mock import patch, mock_open
+	builtins_open = "builtins.open"
+except:
+	from mock import patch, mock_open
+	builtins_open = "__builtin__.open"
 
 
 class TestRules(unittest.TestCase):
+
+	@classmethod
+	def setUpClass(cls):
+		cls.DEFINITIONS = [x for x in Rules.DEFINITIONS
+						   if x.startswith(DATA_DIR)]
+
+	def setUp(self):
+		Rules.DEFINITIONS = self.DEFINITIONS
+		Rules._rules = None
 
 	def test_rules_types(self):
 		for rule in Rules.all():
@@ -42,6 +59,32 @@ class TestRules(unittest.TestCase):
 
 		r1.update(r2)
 		self.assertEqual(r1.action, "baz")
+
+	def test_load(self):
+		"""
+		Test parsing a single XML file with rules
+		"""
+		Rules.DEFINITIONS = ["whatever-file.xml"]
+		data = (
+			"<rules>"
+			"    <rule name='foo' action='return' />"
+			"    <rule name='bar' />"
+			"</rules>"
+		)
+		with patch(builtins_open, mock_open(read_data=data)):
+			rules = Rules.all()
+			self.assertEqual(len(rules), 2)
+			self.assertTrue(all([isinstance(x, Rule) for x in rules]))
+			self.assertEqual(rules[0].name, "foo")
+			self.assertEqual(rules[0].action, "return")
+			self.assertEqual(rules[1].name, "bar")
+
+	def _count(self, app_name, apps):
+		count = 0
+		for a in apps:
+			if a.name == app_name:
+				count += 1
+		return count
 
 
 if __name__ == '__main__':

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -17,6 +17,7 @@ except:
 
 class TestRules(unittest.TestCase):
 	def setUp(self):
+		Applications._apps = ApplicationsCollection()
 		self.tracer = Tracer(PackageManagerMock(), Rules, Applications, memory=dump_memory_mock)
 		self.tracer.timestamp = 5555  # Sure, it should be a UNIX timestamp value
 		Applications._append_application({"name": "kernel", "ignore": True})

--- a/tracer.spec
+++ b/tracer.spec
@@ -60,18 +60,14 @@ Obsoletes:      %{name} <= 0.6.11
 BuildRequires:  python2-devel
 BuildRequires:  python2-sphinx
 %if 0%{?rhel} && 0%{?rhel} <= 7
-BuildRequires:  python-beautifulsoup4
 BuildRequires:  rpm-python
 BuildRequires:  python-lxml
 BuildRequires:  python2-mock
 Requires:       rpm-python
-Requires:       python-beautifulsoup4
 Requires:       python-lxml
 %else
-BuildRequires:  python2-beautifulsoup4
 BuildRequires:  python2-rpm
 Requires:       python2-rpm
-Requires:       python2-beautifulsoup4
 Requires:       python2-lxml
 %endif
 BuildRequires:  python2-pytest
@@ -103,11 +99,9 @@ BuildRequires:  python3-sphinx
 BuildRequires:  python3-pytest
 BuildRequires:  python3-psutil
 BuildRequires:  python3-future
-BuildRequires:  python3-beautifulsoup4
 BuildRequires:  python3-dbus
 BuildRequires:  python3-rpm
 Requires:       python3-rpm
-Requires:       python3-beautifulsoup4
 Requires:       python3-psutil
 Requires:       python3-lxml
 Requires:       python3-setuptools


### PR DESCRIPTION
Beautiful Soup package is not available on all systems (e.g. RHEL 8)
which complicates porting Tracer to such distributions. At the same
time, we don't really need any special feature from bs4 that built-in
`xml.dom.minidom` implementation doesn't provide as well.

I am also adding (and fixing) some tests to make sure the XML parsing
worked, and still works, as expected.