### PR TITLE
Depend on python3-six instead of python3-future

### DIFF
--- a/tracer.spec
+++ b/tracer.spec
@@ -72,7 +72,7 @@ Requires:       python2-lxml
 %endif
 BuildRequires:  python2-pytest
 BuildRequires:  python2-psutil
-BuildRequires:  python2-future
+BuildRequires:  python2-six
 BuildRequires:  dbus-python
 Requires:       dbus-python
 Requires:       python2-psutil
@@ -98,7 +98,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-sphinx
 BuildRequires:  python3-pytest
 BuildRequires:  python3-psutil
-BuildRequires:  python3-future
+BuildRequires:  python3-six
 BuildRequires:  python3-dbus
 BuildRequires:  python3-rpm
 Requires:       python3-rpm
@@ -106,7 +106,7 @@ Requires:       python3-psutil
 Requires:       python3-lxml
 Requires:       python3-setuptools
 Requires:       python3-dbus
-Requires:       python3-future
+Requires:       python3-six
 Requires:       %{name}-common = %{version}-%{release}
 %if %{with suggest}
 Suggests:       python3-argcomplete

--- a/tracer/resources/processes.py
+++ b/tracer/resources/processes.py
@@ -25,7 +25,7 @@ import os
 import re
 from subprocess import PIPE, Popen
 from threading import Timer
-from future.utils import with_metaclass
+from six import with_metaclass
 
 
 class Processes(object):


### PR DESCRIPTION
The `python3-future` package is not available in RHEL 8, and the
`python3-six` is a recommended way of importing `with_metaclass` anyway.
I spent a couple of hours debugging this thinking that there is
somemething wrong with `__future__` which is not the issue at all.