### PR TITLE
Print a user-friendly error when a xml file cannot be parsed

### DIFF
--- a/tracer/main.py
+++ b/tracer/main.py
@@ -23,7 +23,13 @@ import time
 from tracer.resources.router import Router
 from tracer.resources.args_parser import parser
 from tracer.resources.package import Package
-from tracer.resources.exceptions import UnsupportedDistribution, PathNotFound, LockedDatabase, DatabasePermissions
+from tracer.resources.exceptions import (
+	TracerError,
+	UnsupportedDistribution,
+	PathNotFound,
+	LockedDatabase,
+	DatabasePermissions,
+)
 from tracer.resources.lang import _
 
 
@@ -50,6 +56,9 @@ def run():
 	except DatabasePermissions as ex:
 		ex.print()
 		print(_("You will probably need to run tracer as root"))
+		exit(1)
+	except TracerError as ex:
+		ex.print()
 		exit(1)
 	except (KeyboardInterrupt, EOFError):
 		print("")

--- a/tracer/resources/applications.py
+++ b/tracer/resources/applications.py
@@ -19,8 +19,9 @@
 from __future__ import absolute_import
 
 from xml.dom import minidom
+from xml.parsers.expat import ExpatError
 from tracer.paths import DATA_DIR, USER_CONFIG_DIRS
-from tracer.resources.exceptions import PathNotFound
+from tracer.resources.exceptions import PathNotFound, TracerError
 from tracer.resources.collections import ApplicationsCollection
 from tracer.resources.lang import _
 from tracer.resources.processes import Processes
@@ -86,6 +87,9 @@ class Applications(object):
 				xmldoc = minidom.parseString(f.read())
 		except IOError:
 			raise PathNotFound('DATA_DIR')
+		except ExpatError as ex:
+			msg = "Unable to parse {0}\nHint: {1}".format(file, ex)
+			raise TracerError(msg)
 
 		for applications in xmldoc.getElementsByTagName("applications"):
 			cls._remove_unwanted_children(applications)

--- a/tracer/resources/exceptions.py
+++ b/tracer/resources/exceptions.py
@@ -30,6 +30,14 @@ class Printable(object):
 		print(self.message.encode("utf-8") if version_info.major == 2 else self.message)
 
 
+class TracerError(Exception, Printable):
+	"""
+	Unspecified tracer error
+	"""
+	def __init__(self, message):
+		self.message = message
+
+
 class UnsupportedDistribution(OSError, Printable):
 
 	@property

--- a/tracer/resources/rules.py
+++ b/tracer/resources/rules.py
@@ -19,8 +19,9 @@
 from __future__ import absolute_import
 
 from xml.dom import minidom
+from xml.parsers.expat import ExpatError
 from tracer.paths import DATA_DIR, USER_CONFIG_DIRS
-from tracer.resources.exceptions import PathNotFound
+from tracer.resources.exceptions import PathNotFound, TracerError
 from os.path import dirname
 
 
@@ -67,6 +68,9 @@ class Rules(object):
 				xmldoc = minidom.parseString(f.read())
 		except IOError:
 			raise PathNotFound('DATA_DIR')
+		except ExpatError as ex:
+			msg = "Unable to parse {0}\nHint: {1}".format(file, ex)
+			raise TracerError(msg)
 
 		for rules in xmldoc.getElementsByTagName("rules"):
 			for rule in rules.getElementsByTagName("rule"):


### PR DESCRIPTION
We can define custom applications and rules for example in
`~/.config/tracer/applications.xml` and `~/.config/tracer/rules.xml`.
When there is an syntax error, we want to print something like

	Unable to parse /home/jkadlcik/.config/tracer/rules.xml
	Hint: not well-formed (invalid token): line 4, column 0

Instead of

	File "/usr/lib64/python3.9/xml/dom/minidom.py", line 1998, in parseString
		return expatbuilder.parseString(string)
	File "/usr/lib64/python3.9/xml/dom/expatbuilder.py", line 925, in parseString
		return builder.parseString(string)
	File "/usr/lib64/python3.9/xml/dom/expatbuilder.py", line 223, in parseString
		parser.Parse(string, True)
	xml.parsers.expat.ExpatError: not well-formed (invalid token): line 4, column 0