### PR TITLE
CentOS uses DNF

### DIFF
--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 import os.path
 
 from tracer.resources.system import System
-if System.distribution() in ["rhel", "fedora", "mageia", "suse"]:
+if System.distribution() in ["rhel", "fedora", "centos", "centos-7", "mageia", "suse"]:
 
 	import subprocess
 	from tracer.packageManagers.rpm import Rpm

--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "rhel", "centos", "mageia", "ol"]:
+if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "mageia", "ol"]:
 
 	from os import listdir
 	from .ipackageManager import IPackageManager

--- a/tracer/packageManagers/yum.py
+++ b/tracer/packageManagers/yum.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 
 from tracer.resources.system import System
-if System.distribution() in ["fedora", "rhel", "centos", "ol"]:
+if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "ol"]:
 
 	from tracer.packageManagers.rpm import Rpm
 

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -50,6 +50,9 @@ class System(object):
 						os_release_key, os_release_value = line.split("=")
 						os_release_data[os_release_key] = os_release_value.strip('"')
 				if os_release_data["ID"] in distros:
+					# Special case since centos 7 has only yum, but centos-8 uses dnf
+					if os_release_data["ID"] == "centos" and os_release_data["VERSION_ID"] == 7:
+						return "centos-7"
 					return os_release_data["ID"]
 				else:
 					if "ID_LIKE" in os_release_data:
@@ -76,7 +79,11 @@ class System(object):
 				("tracer.packageManagers.dnf", "Dnf"),
 				("tracer.packageManagers.yum", "Yum"),
 			],
-			"centos":  [("tracer.packageManagers.yum", "Yum")],
+			"centos":  [
+				("tracer.packageManagers.dnf", "Dnf"),
+				("tracer.packageManagers.yum", "Yum"),
+			],
+			"centos-7":  [("tracer.packageManagers.yum", "Yum")],
 			"ol":      [("tracer.packageManagers.yum", "Yum")],
 			"mageia":  [("tracer.packageManagers.dnf", "Dnf")],
 			"arch":    [("tracer.packageManagers.alpm", "Alpm")],


### PR DESCRIPTION
Without this patch tracer always returns empty result as by default
`dnf` is being used on centos and not `yum`.