### PR TITLE
Add missing runtime dependency on python2-six

### DIFF
--- a/tracer.spec
+++ b/tracer.spec
@@ -78,6 +78,7 @@ Requires:       dbus-python
 Requires:       python2-psutil
 Requires:       python2-setuptools
 Requires:       python2-future
+Requires:       python2-six
 Requires:       %{name}-common = %{version}-%{release}
 %if %{with suggest}
 Suggests:       python-argcomplete


### PR DESCRIPTION
We already `BuildRequires` it so everything builds successfully but
execution on EPEL7 fails with the following error

    [root@60d227f15636 /]# tracer
    Traceback (most recent call last):
    File "/usr/bin/tracer", line 33, in <module>
	import tracer.main
    File "/usr/lib/python2.7/site-packages/tracer/__init__.py", line 3, in <module>
	from tracer.query import Query
    File "/usr/lib/python2.7/site-packages/tracer/query.py", line 19, in <module>
	from tracer.resources.tracer import Tracer
    File "/usr/lib/python2.7/site-packages/tracer/resources/tracer.py", line 24, in <module>
	from tracer.resources.system import System
    File "/usr/lib/python2.7/site-packages/tracer/resources/system.py", line 31, in <module>
	from tracer.resources.processes import Process
    File "/usr/lib/python2.7/site-packages/tracer/resources/processes.py", line 28, in <module>
	from six import with_metaclass
    ImportError: No module named six