### PR TITLE
Make sure Collection.sorted doesn't traceback for None values

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -61,3 +61,24 @@ class TestCollections(unittest.TestCase):
 		assert {a.name for a in c1} == {"foo", "bar", "baz"}
 		c1.replace_values("name", "foo", "qux")
 		assert {a.name for a in c1} == {"qux", "bar", "baz"}
+
+	def test_collection_sorted_callable(self):
+		c1 = Processes.all()
+		c2 = c1.sorted("create_time")
+
+		for i in range(len(c2) - 1):
+			if c2[i].create_time() > c2[i+1].create_time():
+				raise Exception("The collection isn't sorted properly")
+
+	def test_application_sorted_none_helper(self):
+		"""
+		https://github.com/FrostyX/tracer/issues/151
+		https://github.com/FrostyX/tracer/issues/156
+		"""
+		default_type = Applications.DEFAULT_TYPE
+		a1 = Application({'name': 'foo', 'helper': None, 'type': default_type})
+		a2 = Application({'name': 'baz', 'helper': 'qux', 'type': default_type})
+		collection = ApplicationsCollection([a1, a2])
+		collection_sorted = collection.sorted('helper')
+		self.assertEqual([app.helper for app in collection_sorted],
+						 ["qux", None])


### PR DESCRIPTION
Fix #151
Fix #156
RHBZ 1958779
RHBZ 1940718
MGABZ 28577

I was trying to fix this issue several times already and the best
summary I could write was this one

https://github.com/FrostyX/tracer/issues/151#issuecomment-660066481

It doesn't any sense to me since the problematic line is

    self.args.applications.with_helpers().exclude_types(types).sorted("helper")

which first filters only applications that have non-`None` helper and
only those try to sort, i.e. when sorting there shouldn't be any
`None` values.

Anyway, the issue is real and occurs to many people, so I am reworking
the sorting function and making sure it doesn't traceback when some
helper is `None`. I have no idea what are the problematic applications
and how they will be displayed in the output but I guess everything is
better than a traceback. And maybe it will help us move closer to a
proper solution.