### PR TITLE
Don't traceback for nonexisting PID

### DIFF
--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,5 +1,6 @@
 from .__meta__ import *
 from tracer.resources.processes import Processes, Process, ProcessWrapper
+from tracer.resources.SystemdDbus import SystemdDbus
 from tracer.resources.collections import ProcessesCollection
 import os
 import subprocess
@@ -63,6 +64,14 @@ class TestProcesses(unittest.TestCase):
 		p3.data = {"name": "sshd", "exe": "/usr/sbin/sshd",
 			   "cmdline": ["withoutparams"]}
 		assert p3.name() == "sshd"
+
+	@unittest.skipIf(True, "@TODO Create Mock for Processes class")
+	def test_dbus(self):
+		dbus = SystemdDbus()
+		pids = Processes.pids()
+		nonexisting = max(pids) + 999
+		assert dbus.has_service_property_from_pid(1, "PAMName") is False
+		assert dbus.has_service_property_from_pid(nonexisting, "PAMName") is False
 
 
 class ProcessMock(ProcessWrapper):

--- a/tracer/resources/SystemdDbus.py
+++ b/tracer/resources/SystemdDbus.py
@@ -36,7 +36,11 @@ class SystemdDbus(object):
 
 	def has_service_property_from_pid(self, pid, attr):
 		try:
-			proxy = dbus.SystemBus().get_object('org.freedesktop.systemd1', self.unit_path_from_pid(pid))
+			unit = self.unit_path_from_pid(pid)
+			if not unit:
+				return False
+
+			proxy = dbus.SystemBus().get_object('org.freedesktop.systemd1', unit)
 			propty = proxy.Get('org.freedesktop.systemd1.Service', attr, dbus_interface='org.freedesktop.DBus.Properties')
 		except dbus.exceptions.DBusException:
 			return False


### PR DESCRIPTION
Fix #122

If we cannot find any unit/process with a given PID, simply return
`False` as for other unsuccessful cases.