### PR TITLE
Use distro.id() instead of platform.linux_distribution()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx_rtd_theme
 Pygments
 dbus-python
 future
+distro

--- a/tests/__meta__.py
+++ b/tests/__meta__.py
@@ -4,7 +4,6 @@ parentdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 os.sys.path.insert(0, parentdir)
 
 import sys
-import platform
 import unittest
 from tracer.resources.system import System
 

--- a/tracer.spec
+++ b/tracer.spec
@@ -71,11 +71,13 @@ BuildRequires:  python2-pytest
 BuildRequires:  python2-psutil
 BuildRequires:  python2-six
 BuildRequires:  dbus-python
+BuildRequires:  python2-distro
 Requires:       dbus-python
 Requires:       python2-psutil
 Requires:       python2-setuptools
 Requires:       python2-future
 Requires:       python2-six
+Requires:       python2-distro
 Requires:       %{name}-common = %{version}-%{release}
 %if %{with suggest}
 Suggests:       python-argcomplete
@@ -99,11 +101,13 @@ BuildRequires:  python3-psutil
 BuildRequires:  python3-six
 BuildRequires:  python3-dbus
 BuildRequires:  python3-rpm
+BuildRequires:  python3-distro
 Requires:       python3-rpm
 Requires:       python3-psutil
 Requires:       python3-setuptools
 Requires:       python3-dbus
 Requires:       python3-six
+Requires:       python3-distro
 Requires:       %{name}-common = %{version}-%{release}
 %if %{with suggest}
 Suggests:       python3-argcomplete

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 import pwd
 import importlib
-import platform
+import distro
 import psutil
 from sys import version_info
 from tracer.resources.PackageManager import PackageManager
@@ -37,7 +37,7 @@ class System(object):
 		"""
 		Checks if /etc/os-release exists, and if it does, uses it to divine the name of the distribution or
 		distribution like. e.g It will return 'debian' on Ubuntu systems.
-		Otherwise, revert to using platform.linux_distribution()
+		Otherwise, revert to using distro.id()
 		"""
 		if os.path.isfile("/etc/os-release"):
 			with open("/etc/os-release") as os_release_file:
@@ -56,11 +56,11 @@ class System(object):
 					return os_release_data["ID"]
 				else:
 					if "ID_LIKE" in os_release_data:
-						for distro in os_release_data["ID_LIKE"].split():
-							if distro in distros:
-								return distro
+						for distribution in os_release_data["ID_LIKE"].split():
+							if distribution in distros:
+								return distribution
 		else:
-			return platform.linux_distribution(full_distribution_name=False)[0]
+			return distro.id()
 
 	@staticmethod
 	def package_manager(**kwargs):
@@ -95,11 +95,11 @@ class System(object):
 			"suse":  [("tracer.packageManagers.dnf", "Dnf")],
 		}
 
-		distro = System.distribution()
-		if distro not in managers:
+		distribution = System.distribution()
+		if distribution not in managers:
 			return None
 
-		return PackageManager(*list(map(get_instance, managers[distro])))
+		return PackageManager(*list(map(get_instance, managers[distribution])))
 
 	@staticmethod
 	def init_system():


### PR DESCRIPTION
Fix #175

We also needed to rename all variables named `distro` to not shadow
the imported module name.