### PR TITLE
Drop beautifulsoup4/lxml dependencies

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $script = <<SCRIPT
     sudo dnf install -y tito tracer
 
     # the following deps fail during the tito --install due to tito using --cache-only option, so install them beforehand
-    sudo dnf install -y python2-beautifulsoup4 python2-cssselect python2-html5lib python2-rpm python2-webencodings python2-future python2-psutil
+    sudo dnf install -y python2-cssselect python2-html5lib python2-rpm python2-webencodings python2-future python2-psutil
 
     sudo dnf builddep -y tracer.spec
     tito build --rpm --test --install

--- a/doc/source/developer-guide.rst
+++ b/doc/source/developer-guide.rst
@@ -7,7 +7,6 @@ Python
 Tracer is written in Python and it is compatible with its both 2.7 and 3.x versions. Besides standard python interpreter, tracer requires its few packages:
 
 - `psutil`_ - For getting informations about processes, memory, etc
-- `beautifulsoup`_ - For parsing user defined xml files such as ``data/applications.xml`` and ``data/rules.xml``
 
 Coding style
 ------------
@@ -88,7 +87,6 @@ Fedora
 
 
 .. _psutil: https://code.google.com/p/psutil/
-.. _beautifulsoup: http://www.crummy.com/software/BeautifulSoup/bs4/doc/
 .. _tito: https://github.com/dgoodwin/tito
 .. _Makefile: https://github.com/FrostyX/tracer/blob/master/Makefile
 .. _copr: https://copr.fedoraproject.org/coprs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ psutil
 BeautifulSoup4
 sphinx_rtd_theme
 Pygments
-lxml<4.0.0; python_version == '3.4'
-lxml; python_version != '3.4'
 dbus-python
 future

--- a/tracer.spec
+++ b/tracer.spec
@@ -61,14 +61,11 @@ BuildRequires:  python2-devel
 BuildRequires:  python2-sphinx
 %if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires:  rpm-python
-BuildRequires:  python-lxml
 BuildRequires:  python2-mock
 Requires:       rpm-python
-Requires:       python-lxml
 %else
 BuildRequires:  python2-rpm
 Requires:       python2-rpm
-Requires:       python2-lxml
 %endif
 BuildRequires:  python2-pytest
 BuildRequires:  python2-psutil
@@ -104,7 +101,6 @@ BuildRequires:  python3-dbus
 BuildRequires:  python3-rpm
 Requires:       python3-rpm
 Requires:       python3-psutil
-Requires:       python3-lxml
 Requires:       python3-setuptools
 Requires:       python3-dbus
 Requires:       python3-six


### PR DESCRIPTION
In 9abc7eab6dd39146136 bs4 was dropped as dependency, but not from the
Vagrantfile and requirements.txt. lxml was used for HTML parsing with
bs4 and can also be dropped from requirements and packaging.