### PR TITLE
Add find_package support for alpm

### DIFF
--- a/tracer/packageManagers/alpm.py
+++ b/tracer/packageManagers/alpm.py
@@ -78,6 +78,14 @@ if System.distribution() in ["arch", "archarm"]:
 			process = app.instances[0]
 			return self._file_provided_by(process.exe)
 
+		def find_package(self, pkg_name, version):
+			"""
+			Find a package by name and some other input criteria
+			"""
+			pkg = self.db.get_pkg(pkg_name)
+			if pkg and pyalpm.vercmp(pkg.version, version) == 0:
+				return pkg
+
 		@staticmethod
 		def _bsearch_list(l, item):
 			"""

--- a/tracer/packageManagers/alpm.py
+++ b/tracer/packageManagers/alpm.py
@@ -86,6 +86,15 @@ if System.distribution() in ["arch", "archarm"]:
 			if pkg and pyalpm.vercmp(pkg.version, version) == 0:
 				return pkg
 
+		def compare_packages(self, package1, package2):
+			"""
+			vercmp returns:
+			< 0 if ver1 < ver2
+			0 if ver1 == ver2
+			> 0 if ver1 > ver2
+			"""
+			return pyalpm.vercmp(package1.version, package2.version)
+
 		@staticmethod
 		def _bsearch_list(l, item):
 			"""


### PR DESCRIPTION
Implement a naive find_package for alpm which simply checks if the given
version corresponds to the installed package version.

This does not make the kernel version check work yet on Arch Linux, as the `kernel` package is hardcoded in code, but at least it does not make `tracer` throw a backtrace when running.