### PR TITLE
Drop python-setuptools runtime dependency

### DIFF
--- a/tracer.spec
+++ b/tracer.spec
@@ -74,7 +74,6 @@ BuildRequires:  dbus-python
 BuildRequires:  python2-distro
 Requires:       dbus-python
 Requires:       python2-psutil
-Requires:       python2-setuptools
 Requires:       python2-future
 Requires:       python2-six
 Requires:       python2-distro
@@ -104,7 +103,6 @@ BuildRequires:  python3-rpm
 BuildRequires:  python3-distro
 Requires:       python3-rpm
 Requires:       python3-psutil
-Requires:       python3-setuptools
 Requires:       python3-dbus
 Requires:       python3-six
 Requires:       python3-distro


### PR DESCRIPTION
Fix #183

It was introduced in 15ad905 in order to compare version numbers,
however the code was reworked and we don't use it anymore.