### PR TITLE
Fix argument passed to print_helper()

### DIFF
--- a/tracer/controllers/default.py
+++ b/tracer/controllers/default.py
@@ -74,7 +74,7 @@ class DefaultController(object):
 	def render_helpers(self):
 		helper_controller = HelperController(self.args)
 		for application in self._restartable_applications(self.applications, self.args):
-			helper_controller.print_helper(application.name, self.args)
+			helper_controller.print_helper(application, self.args)
 			print("")
 
 		view = NoteForHiddenView()


### PR DESCRIPTION
`print_helper()` takes an application, not an application name, as its first argument, and expects that argument to have an attribute named `instances`:

https://github.com/FrostyX/tracer/blob/b390877a743ab9e7fd4857ed7bfcbf92d35c991c/tracer/controllers/helper.py#L45-L48

Clears up a traceback when running `tracer` with `--helpers`:

```text
$ sudo tracer -iat 1653306651.5944774 --helpers
Traceback (most recent call last):
  File "/usr/bin/tracer", line 34, in <module>
    tracer.main.run()
  File "/usr/lib/python3.10/site-packages/tracer/main.py", line 51, in run
    return router.dispatch()
  File "/usr/lib/python3.10/site-packages/tracer/resources/router.py", line 54, in dispatch
    controller.render_helpers()
  File "/usr/lib/python3.10/site-packages/tracer/controllers/default.py", line 77, in render_helpers
    helper_controller.print_helper(application.name, self.args)
  File "/usr/lib/python3.10/site-packages/tracer/controllers/helper.py", line 46, in print_helper
    if app.instances:
AttributeError: 'str' object has no attribute 'instances'
```