### PR TITLE
Stop using deprecated rpm.fi

### DIFF
--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -102,8 +102,8 @@ if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "mageia", "
 			if self._is_installed(pkg_name):
 				ts = rpm.TransactionSet()
 				mi = ts.dbMatch("name", pkg_name)
-				fi = rpm.fi(next(mi))
-				return [f[0] for f in fi]
+				hdr = next(mi)
+				return [x.name for x in rpm.files(hdr)]
 
 			# Tracer will not find uninstalled applications
 			return []


### PR DESCRIPTION
Fix #198

Per `help(rpm.fi)`:

> DEPRECATED! This old API mixes storing and iterating over the meta data
> of the files of a package. Use rpm.files and rpm.file data types as a
> much cleaner API.

We could use

    return [x.name for x in rpm.files(hdr)]

but this seems easier

    return hdr[rpm.RPMTAG_FILENAMES]