### PR TITLE
Massive performance boost

### DIFF
--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -48,12 +48,10 @@ if System.distribution() in ["rhel", "fedora", "centos", "centos-7", "mageia", "
 				return '/var/lib/dnf/history/'
 
 		def package_files(self, pkg_name):
-			if self._is_installed(pkg_name):
+			if not self.opts.get("erased"):
 				return super(Dnf, self).package_files(pkg_name)
 
-			if "erased" not in self.opts or not self.opts["erased"]:
-				return []
-
+			# TODO Running an external command is tooooo slow, use python API instead
 			process = subprocess.Popen(["dnf", "repoquery", "-q", "-l", pkg_name], stdout=subprocess.PIPE)
 			out = process.communicate()[0]
 			return out.decode().split("\n")

--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -100,11 +100,11 @@ if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "mageia", "
 			Returns list of files provided by package
 			See also: http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch04s02s03.html
 			"""
-			if self._is_installed(pkg_name):
-				ts = rpm.TransactionSet()
-				mi = ts.dbMatch("name", pkg_name)
-				hdr = next(mi)
-				return [x.name for x in rpm.files(hdr)]
+			ts = rpm.TransactionSet()
+			mi = ts.dbMatch("name", pkg_name)
+			packages = list(mi)
+			if packages:
+				return [x.name for x in rpm.files(packages[0])]
 
 			# Tracer will not find uninstalled applications
 			return []
@@ -228,17 +228,3 @@ if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "mageia", "
 			for file in sorted(listdir(self.history_path), reverse=True):
 				if file.startswith("history-") and file.endswith(".sqlite"):
 					return self.history_path + file
-
-		@classmethod
-		def _is_installed(cls, pkg_name):
-			"""Returns True if package is installed"""
-			# Querying all installed packages at onece is faster than for each
-			# package querying whether it is installed
-			return pkg_name in cls._all_installed_packages()
-
-		@staticmethod
-		@lru_cache(maxsize=None)
-		def _all_installed_packages():
-			ts = rpm.TransactionSet()
-			mi = ts.dbMatch()
-			return [x.name for x in mi]

--- a/tracer/resources/applications.py
+++ b/tracer/resources/applications.py
@@ -205,7 +205,7 @@ class Application:
 	@property
 	@lru_cache(maxsize=None)
 	def is_session(self):
-		if re.search('ssh-.*-session', str(self.name)):
+		if self.name.startswith("ssh-") and self.name.endswith("-session"):
 			return True
 		return self.instances and self.instances[0].is_session
 

--- a/tracer/resources/applications.py
+++ b/tracer/resources/applications.py
@@ -208,14 +208,16 @@ class Application:
 
 	@property
 	def type(self):
-                if not self._attributes["type"] == Applications.TYPES["UNDEF"]:
-                        return self._attributes["type"]
-                elif self.is_session:
-                        return Applications.TYPES["SESSION"]
-                elif self.is_service:
-                        return Applications.TYPES["DAEMON"]
-                else:
-                        return Applications.DEFAULT_TYPE
+		if self._attributes["type"] != Applications.TYPES["UNDEF"]:
+			return self._attributes["type"]
+
+		if self.is_session:
+			return Applications.TYPES["SESSION"]
+
+		if self.is_service:
+			return Applications.TYPES["DAEMON"]
+
+		return Applications.DEFAULT_TYPE
 
 	@property
 	def is_service(self):

--- a/tracer/resources/applications.py
+++ b/tracer/resources/applications.py
@@ -227,7 +227,7 @@ class Application:
 	# @TODO rename to helper_format
 	@property
 	def helper(self):
-		helper = self._attributes["helper"] if self._attributes["helper"] else Applications._helper(self)
+		helper = self._attributes["helper"] or Applications._helper(self)
 		if System.user() != "root" and self.type == Applications.TYPES["DAEMON"]:
 			if helper and not helper.startswith("sudo "):
 				helper = "sudo " + helper

--- a/tracer/resources/processes.py
+++ b/tracer/resources/processes.py
@@ -22,7 +22,6 @@ import psutil
 import datetime
 import time
 import os
-import re
 from subprocess import PIPE, Popen
 from threading import Timer
 from six import with_metaclass
@@ -79,7 +78,8 @@ class ProcessWrapper(object):
 		try:
 			if self._attr("name") == 'sshd':
 				if self._attr("exe") not in self._attr("cmdline") and len(self._attr("cmdline")) > 1:
-					return 'ssh-{0}-session'.format(re.split(' |@',' '.join(self._attr("cmdline")))[1])
+					username= self._attr("cmdline")[1].split("@")[0]
+					return 'ssh-{0}-session'.format(username)
 		except psutil.AccessDenied:
 			pass
 		return self._attr("name")


### PR DESCRIPTION
Fix RHBZ 2094448

I couldn't reproduce the exact

```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
1745231  413.627    0.000  413.627    0.000 {method 'split' of '_sre.SRE_Pattern' objects}
9175435   35.478    0.000  473.426    0.000 /usr/lib/python3.6/site-packages/tracer/resources/processes.py:76(name)
```

from the mentioned RHBZ but I replaced the regex with simpler operations and also added some caching here and there to get a big performance boost.