### PR TITLE
Fix traceback when tracer is called with --erased

### DIFF
--- a/tracer/resources/tracer.py
+++ b/tracer/resources/tracer.py
@@ -114,7 +114,7 @@ class Tracer(object):
 
 							if not a.ignore:
 								if a.name not in affected:
-									if self._erased and not self._PACKAGE_MANAGER.provided_by(a.name):
+									if self._erased and not self._PACKAGE_MANAGER.provided_by(a):
 										a.type = Applications.TYPES["ERASED"]
 									affected[a.name] = AffectedApplication(a._attributes)
 									affected[a.name].affected_instances = AffectedProcessesCollection()


### PR DESCRIPTION
      File "/home/jkadlcik/git/tracer/tracer/resources/tracer.py", line 117, in trace_affected
        if self._erased and not self._PACKAGE_MANAGER.provided_by(a.name):
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/jkadlcik/git/tracer/tracer/resources/PackageManager.py", line 63, in provided_by
        return self.package_managers[0].provided_by(app)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/jkadlcik/git/tracer/tracer/packageManagers/rpm.py", line 165, in provided_by
        process = app.instances[0]  # @TODO Reimplement for all processes
                  ^^^^^^^^^^^^^
    AttributeError: 'str' object has no attribute 'instances'