### PR TITLE
Initial stub out for different kernel packages per distro

### DIFF
--- a/tests/test_alpm.py
+++ b/tests/test_alpm.py
@@ -32,6 +32,11 @@ class TestAlpm(unittest.TestCase):
 		except NotImplementedError: self.fail("provided_by() is not implemented!")
 		except Exception: pass
 
+	def test_package_name_only(self):
+		try: self.manager.package_name_only("")
+		except NotImplementedError: self.fail("package_name_only() is not implemented!")
+		except Exception: pass
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/test_dnf.py
+++ b/tests/test_dnf.py
@@ -32,6 +32,11 @@ class TestDnf(unittest.TestCase):
 		except NotImplementedError: self.fail("provided_by() is not implemented!")
 		except Exception: pass
 
+	def test_package_name_only(self):
+		try: self.manager.package_name_only("")
+		except NotImplementedError: self.fail("package_name_only() is not implemented!")
+		except Exception: pass
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -32,6 +32,11 @@ class TestDpkg(unittest.TestCase):
 		except NotImplementedError: self.fail("provided_by() is not implemented!")
 		except Exception: pass
 
+	def test_package_name_only(self):
+		try: self.manager.package_name_only("")
+		except NotImplementedError: self.fail("package_name_only() is not implemented!")
+		except Exception: pass
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/test_portage.py
+++ b/tests/test_portage.py
@@ -32,6 +32,11 @@ class TestPortage(unittest.TestCase):
 		except NotImplementedError: self.fail("provided_by() is not implemented!")
 		except Exception: pass
 
+	def test_package_name_only(self):
+		try: self.manager.package_name_only("")
+		except NotImplementedError: self.fail("package_name_only() is not implemented!")
+		except Exception: pass
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/test_yum.py
+++ b/tests/test_yum.py
@@ -32,6 +32,11 @@ class TestYum(unittest.TestCase):
 		except NotImplementedError: self.fail("provided_by() is not implemented!")
 		except Exception: pass
 
+	def test_package_name_only(self):
+		try: self.manager.package_name_only("")
+		except NotImplementedError: self.fail("package_name_only() is not implemented!")
+		except Exception: pass
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tracer/packageManagers/README.md
+++ b/tracer/packageManagers/README.md
@@ -6,5 +6,6 @@ Every package manager module should inherit `IPackageManger` class and implement
 - `package_files(self, pkg_name)`
 - `load_package_info(self, package)`
 - `provided_by(self, app)`
+- `package_name_only(self, pkg_object)`
 
 Also there should be unit test for every package manager. Please see [dnf test](https://github.com/FrostyX/tracer/blob/develop/tests/test_dnf.py) for example.

--- a/tracer/packageManagers/alpm.py
+++ b/tracer/packageManagers/alpm.py
@@ -86,6 +86,12 @@ if System.distribution() in ["arch", "archarm"]:
 			if pkg and pyalpm.vercmp(pkg.version, version) == 0:
 				return pkg
 
+		def package_name_only(self, pkg_object):
+			"""
+			Transform our search result into a string with the package name
+			"""
+			return pkg_object.name
+
 		def compare_packages(self, package1, package2):
 			"""
 			vercmp returns:

--- a/tracer/packageManagers/dnf.py
+++ b/tracer/packageManagers/dnf.py
@@ -58,6 +58,12 @@ if System.distribution() in ["rhel", "fedora", "centos", "centos-7", "mageia", "
 			out = process.communicate()[0]
 			return out.decode().split("\n")
 
+		def package_name_only(self, pkg_object):
+			"""
+			Transform our search result into a string with the package name
+			"""
+			return pkg_object.name
+
 
 	class FakeDnf5(Dnf):
 		def packages_newer_than(self, unix_time):

--- a/tracer/packageManagers/dpkg.py
+++ b/tracer/packageManagers/dpkg.py
@@ -77,6 +77,12 @@ if System.distribution() == "debian":
 					files.append(file)
 			return files
 
+		def package_name_only(self, pkg_object):
+			"""
+			Transform our search result into a string with the package name
+			"""
+			return pkg_object.name
+
 		def load_package_info(self, package):
 			"""From database load informations about given package and set them to it"""
 			description = None

--- a/tracer/packageManagers/ipackageManager.py
+++ b/tracer/packageManagers/ipackageManager.py
@@ -46,6 +46,10 @@ class IPackageManager(object):
 		"""Find a package by name and some other input criteria"""
 		raise NotImplementedError
 
+	def package_name_only(self, pkg_object):
+		"""Returns the name of a package from the object found via the search functions"""
+		raise NotImplementedError
+
 	def compare_packages(self, package1, package2):
 		"""
 		Compares two packages by their version information

--- a/tracer/packageManagers/portage.py
+++ b/tracer/packageManagers/portage.py
@@ -95,6 +95,12 @@ if System.distribution() == "gentoo":
 			package.description = description
 			package.category = category
 
+		def package_name_only(self, pkg_object):
+			"""
+			Transform our search result into a string with the package name
+			"""
+			return pkg_object.name
+
 		def provided_by(self, app):
 			"""Returns a package which provides given application"""
 			process = app.instances[0]  # @TODO Reimplement for all processes

--- a/tracer/packageManagers/rpm.py
+++ b/tracer/packageManagers/rpm.py
@@ -129,6 +129,12 @@ if System.distribution() in ["fedora", "rhel", "centos", "centos-7", "mageia", "
 
 			return None
 
+		def package_name_only(self, pkg_object):
+			"""
+			Transform our search result into a string with the package name
+			"""
+			return pkg_object.name
+
 		def load_package_info(self, package):
 			"""From database load informations about given package and set them to it"""
 			if not package:

--- a/tracer/resources/system.py
+++ b/tracer/resources/system.py
@@ -137,12 +137,29 @@ class System(object):
 
 	@staticmethod
 	def running_kernel_package():
-		return System.package_manager().find_package(System.kernel_package_name(), os.uname()[2])
+		for kernel_package in System.kernel_package_names():
+			search_result = System.package_manager().find_package(kernel_package, os.uname()[2])
+			if search_result is not None:
+				return search_result
 
 	@staticmethod
-	def kernel_package_name():
-		""" TODO: infer kernel package from current distribution """
-		return 'kernel'
+	def kernel_package_names():
+		""" TODO: finish list of kernel packages """
+		distribution = System.distribution()
+		if distribution in ['rhel', 'centos']:
+			# RHEL includes kernel, kernel-core, and kernel-rt
+			# ELRepo includes kernel-lt and kernel-ml
+			return ['kernel', 'kernel-core', 'kernel-rt', 'kernel-lt', 'kernel-ml']
+		elif distribution == 'ol':
+			# RHEL includes kernel, kernel-core, and kernel-rt
+			# ELRepo includes kernel-lt and kernel-ml
+			# Oracle includes kernel-uek
+			return ['kernel', 'kernel-core', 'kernel-rt', 'kernel-lt', 'kernel-ml', 'kernel-uek']
+		elif distribution == 'fedora':
+			# Fedora includes kernel, kernel-core
+			return ['kernel', 'kernel-core']
+		else:
+			return ['kernel']
 
 	@staticmethod
 	def user():

--- a/tracer/resources/tracer.py
+++ b/tracer/resources/tracer.py
@@ -137,7 +137,7 @@ class Tracer(object):
 			""" If the running kernel package could not be determined, abort """
 			return False
 
-		kernel_package_name = System.kernel_package_name()
+		kernel_package_name = self._PACKAGE_MANAGER.package_name_only(running)
 		latest = Package(kernel_package_name)
 		latest.load_info(self._PACKAGE_MANAGER)
 


### PR DESCRIPTION
This sets up a skeleton for how multiple "`kernel`" packages might be checked on hosts that have alternate kernels installed (`kernel-rt` or `kernel-ml`) and tries to track updates of the alt kernel rather than the stock kernel.

This passed my minimal smoke test, but I wouldn't call it release ready...

I got lucky that each package manager's search result object has a `.name` attribute :)

I do wonder if there is any value switching those to `@staticmethod` since they just pop off an object attribute?

On the kernel package name front, I wonder if those should just land in the `applications.xml` file as a new type of thing rather than hard coded here?

I still have no idea how to handle "debian" style kernel package names...